### PR TITLE
Fix antd modal deprecation and time tracker apis

### DIFF
--- a/src/app/api/employee/time-tracker/stats/route.ts
+++ b/src/app/api/employee/time-tracker/stats/route.ts
@@ -1,0 +1,64 @@
+// app/api/employee/time-tracker/stats/route.ts
+import { NextResponse } from 'next/server';
+import { TimeTrackerSession } from '@/models/TimeTracker';
+import connectToDatabase from '@/lib/db';
+import { ITimeTrackerApiResponse } from '@/types';
+
+export async function GET(request: Request) {
+  await connectToDatabase();
+  
+  try {
+    const { searchParams } = new URL(request.url);
+    const employeeId = searchParams.get('employeeId');
+    const date = searchParams.get('date');
+    const period = searchParams.get('period') || 'daily';
+    
+    if (!employeeId) {
+      return NextResponse.json({
+        success: false,
+        message: 'Employee ID is required'
+      } satisfies ITimeTrackerApiResponse, { status: 400 });
+    }
+    
+    let stats;
+    const today = new Date();
+    
+    switch (period) {
+      case 'daily': {
+        const targetDate = date ? new Date(date) : today;
+        stats = await TimeTrackerSession.getDailyStats(employeeId, targetDate);
+        break;
+      }
+      case 'weekly': {
+        const startOfWeek = new Date(today);
+        startOfWeek.setDate(today.getDate() - today.getDay());
+        stats = await TimeTrackerSession.getWeeklyStats(employeeId, startOfWeek);
+        break;
+      }
+      case 'monthly': {
+        const month = today.getMonth() + 1;
+        const year = today.getFullYear();
+        stats = await TimeTrackerSession.getMonthlyStats(employeeId, month, year);
+        break;
+      }
+      default:
+        return NextResponse.json({
+          success: false,
+          message: 'Invalid period'
+        } satisfies ITimeTrackerApiResponse, { status: 400 });
+    }
+    
+    return NextResponse.json({
+        success: true,
+        data: stats,
+        message: ''
+    } satisfies ITimeTrackerApiResponse);
+  } catch (error) {
+    return NextResponse.json({
+      success: false,
+      message: 'Failed to get statistics',
+      error: error instanceof Error ? error.message : 'Unknown error'
+    } satisfies ITimeTrackerApiResponse, { status: 500 });
+  }
+}
+

--- a/src/components/Employee/Chat/NewChatModal.tsx
+++ b/src/components/Employee/Chat/NewChatModal.tsx
@@ -181,7 +181,7 @@ export default function NewChatModal({ isOpen, onClose }: NewChatModalProps) {
           {chatType === 'channel' ? 'Create Channel' : 'Start Chat'}
         </Button>,
       ]}
-      destroyOnClose={true}
+      destroyOnHidden={true}
     >
       <div className="space-y-4">
         {/* Chat Type Selector */}


### PR DESCRIPTION
Adds missing time-tracker stats API route and updates deprecated Ant Design Modal prop.

---
<a href="https://cursor.com/background-agent?bcId=bc-0de5030a-029f-4679-9811-cc77b57ef1ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0de5030a-029f-4679-9811-cc77b57ef1ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

